### PR TITLE
hotfix/dont-close-connection-in-NewRelayConnection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func NewRelayConnection(host, authToken string) (RelayClient, error) {
+func NewRelayConnection(host string) (RelayClient, error) {
 
 	// Check initial connection for approval
 	conn, err := grpc.Dial(host, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/conn.go
+++ b/conn.go
@@ -26,7 +26,6 @@ func NewRelayConnection(host, authToken string) (RelayClient, error) {
 
 		conn = newConn
 	}
-	defer conn.Close()
 
 	return NewRelayClient(conn), nil
 }


### PR DESCRIPTION
connection was being closed after NewRelayConnection() returned a client